### PR TITLE
remote host absolute path in launch.json

### DIFF
--- a/remote-debugging-docker/.vscode/launch.json
+++ b/remote-debugging-docker/.vscode/launch.json
@@ -9,7 +9,7 @@
             "type": "python",
             "request": "attach",
             "localRoot": "${workspaceFolder}",
-            "remoteRoot": "src/",
+            "remoteRoot": "/src/",
             "port": 3000,
             "secret": "my_secret",
             "host": "localhost"


### PR DESCRIPTION
Had to put an absolute path for launch.json in order debugger to pick up the variables and things. Otherwise it stops but not reporting anything.