### PR TITLE
Fixed path mapping in launch.json

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,23 @@
+// launch.json
+
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Python: Remote Attach",
+            "type": "python",
+            "request": "attach",
+            "port": 3000,
+            "host": "localhost",
+            "pathMappings": [
+                {
+                    "localRoot": "${workspaceFolder}/remote-debugging-docker",
+                    "remoteRoot": "./src"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Trying to run the existing remote-dubugging-docker example yielded the following error when trying to attach the debugger:

`pydev debugger: warning: trying to add breakpoint to file that does not exist: /src/remote-debugging-docker/sample.py (will have no effect)
`
