### PR TITLE
Adding automatic docker container build in vscode launch config of remote docker debugging

### DIFF
--- a/remote-debugging-docker/.vscode/launch.json
+++ b/remote-debugging-docker/.vscode/launch.json
@@ -5,7 +5,7 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Attach (Remote Debug)",
+            "name": "Build and Attach (Remote Debug)",
             "type": "python",
             "request": "attach",
             "port": 3000,
@@ -16,6 +16,17 @@
             "redirectOutput": false,
             "preLaunchTask": "Start Debug",
             "postDebugTask": "End Debug"
+        },
+        {
+            "name": "Attach (Remote Debug)",
+            "type": "python",
+            "request": "attach",
+            "port": 3000,
+            "host": "localhost",
+            "pathMappings": [
+                {"localRoot": "${workspaceFolder}", "remoteRoot": "/src/"}
+            ],
+            "redirectOutput": false
         }
     ]
 }

--- a/remote-debugging-docker/.vscode/launch.json
+++ b/remote-debugging-docker/.vscode/launch.json
@@ -13,7 +13,9 @@
             "pathMappings": [
                 {"localRoot": "${workspaceFolder}", "remoteRoot": "/src/"}
             ],
-            "redirectOutput": false
+            "redirectOutput": false,
+            "preLaunchTask": "Start Debug",
+            "postDebugTask": "End Debug"
         }
     ]
 }

--- a/remote-debugging-docker/.vscode/tasks.json
+++ b/remote-debugging-docker/.vscode/tasks.json
@@ -1,0 +1,15 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Start Debug",
+            "command": "./debug.sh start && sleep 3",
+            "type": "shell"
+        },
+        {
+            "label": "End Debug",
+            "type": "shell",
+            "command": "./debug.sh stop"
+        }
+    ]
+}

--- a/remote-debugging-docker/README.md
+++ b/remote-debugging-docker/README.md
@@ -20,3 +20,9 @@
 * Add a breakpoint to the line `print("attached")`
 * Go into the debugger menu and select `Python: Attach` and press the green arrow icon 
 * Wait for around 2 seconds and the debugger should hit at the breakpoint
+
+## Using automatic build of docker container
+It's the above steps combined in one.
+* Add a breakpoint to the line `print("attached")`
+* Go into the debugger menu and select `Python: Build and Attach` and press the green arrow icon 
+* Wait for a little time and the debugger should hit at the breakpoint

--- a/remote-debugging-docker/debug.sh
+++ b/remote-debugging-docker/debug.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+if [ "$1" == "start" ]; then
+    docker build -t remote-debugging-docker .
+    docker run -d -t -p 3000:3000 --name remote-dbg-docker remote-debugging-docker
+elif [ "$1" == "stop" ]; then
+    docker stop remote-dbg-docker
+    docker rm remote-dbg-docker
+fi


### PR DESCRIPTION
I just added an automatic build of the docker container when starting a debugging session. Maybe this is useful for others.